### PR TITLE
Add strict publish workflow with verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,34 @@ const logger = createLogger({
 logger.info('Hello, world!')
 ```
 
+## 開発者向け
+
+### パッケージの公開
+
+このプロジェクトでは厳格な公開ワークフローを採用しています：
+
+```bash
+# 通常の公開（推奨）- 事前検証付き
+npm run publish
+
+# 検証のみ実行
+npm run verify-publish
+
+# 強制公開（検証をスキップ） - 緊急時のみ使用
+npm run publish:force
+```
+
+**重要な仕様：**
+- privateパッケージ（`@logone/dev-config`, `@logone/test-helper`）は自動的に公開対象から除外
+- 公開前に対象パッケージと除外パッケージが明確に表示され、手動確認が必要
+- changeset設定で明示的にprivateパッケージを除外
+
+### 新しいパッケージの追加
+
+1. `packages/` 配下に新しいディレクトリを作成
+2. privateパッケージの場合は `package.json` で `"private": true` を設定
+3. privateパッケージは `.changeset/config.json` の `ignore` リストに追加
+
 ## ライセンス
 
 MIT

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "test": "turbo run test",
     "changeset": "changeset",
     "version": "npm run format && npm run lint && changeset version && npm install",
-    "publish": "changeset publish"
+    "publish": "npm run verify-publish && changeset publish",
+    "verify-publish": "node scripts/verify-publish.js",
+    "publish:force": "changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",

--- a/scripts/verify-publish.js
+++ b/scripts/verify-publish.js
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+// 設定
+const WORKSPACE_ROOT = path.resolve(__dirname, '..');
+const PACKAGES_DIR = path.join(WORKSPACE_ROOT, 'packages');
+
+/**
+ * パッケージ情報を取得
+ */
+function getPackageInfo(packagePath) {
+  const packageJsonPath = path.join(packagePath, 'package.json');
+  
+  if (!fs.existsSync(packageJsonPath)) {
+    return null;
+  }
+  
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    return {
+      name: packageJson.name,
+      version: packageJson.version,
+      private: packageJson.private === true,
+      path: packagePath,
+      publishConfig: packageJson.publishConfig || {}
+    };
+  } catch (error) {
+    console.error(`Error reading ${packageJsonPath}:`, error.message);
+    return null;
+  }
+}
+
+/**
+ * 全パッケージの情報を収集
+ */
+function getAllPackages() {
+  const packages = [];
+  
+  if (!fs.existsSync(PACKAGES_DIR)) {
+    console.error('packages directory not found');
+    process.exit(1);
+  }
+  
+  const packageDirs = fs.readdirSync(PACKAGES_DIR, { withFileTypes: true })
+    .filter(dirent => dirent.isDirectory())
+    .map(dirent => dirent.name);
+  
+  for (const dir of packageDirs) {
+    const packagePath = path.join(PACKAGES_DIR, dir);
+    const packageInfo = getPackageInfo(packagePath);
+    
+    if (packageInfo) {
+      packages.push(packageInfo);
+    }
+  }
+  
+  return packages;
+}
+
+/**
+ * changeset statusの情報を取得
+ */
+function getChangesetStatus() {
+  try {
+    // まずchangeset statusで情報を取得しようとする
+    const output = execSync('npx changeset status --output=json', {
+      cwd: WORKSPACE_ROOT,
+      encoding: 'utf8'
+    });
+    return JSON.parse(output);
+  } catch (error) {
+    console.warn('Warning: Could not get changeset status:', error.message.split('\n')[0]);
+    return null;
+  }
+}
+
+/**
+ * 公開対象パッケージを表示
+ */
+function displayPublishablePackages(packages, changesetStatus) {
+  const publicPackages = packages.filter(pkg => !pkg.private);
+  const privatePackages = packages.filter(pkg => pkg.private);
+  
+  console.log('\n=== PUBLISH VERIFICATION ===\n');
+  
+  // Private packages (excluded from publish)
+  console.log('🔒 PRIVATE PACKAGES (will NOT be published):');
+  if (privatePackages.length === 0) {
+    console.log('  (none)');
+  } else {
+    privatePackages.forEach(pkg => {
+      console.log(`  - ${pkg.name}@${pkg.version} (private: true)`);
+    });
+  }
+  
+  console.log('\n📦 PUBLIC PACKAGES:');
+  if (publicPackages.length === 0) {
+    console.log('  (none)');
+  } else {
+    publicPackages.forEach(pkg => {
+      const willPublish = changesetStatus?.releases?.some(release => 
+        release.name === pkg.name && release.type !== 'none'
+      ) || false;
+      
+      const status = willPublish ? '✅ WILL BE PUBLISHED' : '⏸️  No changes';
+      console.log(`  - ${pkg.name}@${pkg.version} ${status}`);
+    });
+  }
+  
+  // Show packages that will actually be published
+  if (changesetStatus?.releases) {
+    const packagesToPublish = changesetStatus.releases.filter(release => 
+      release.type !== 'none'
+    );
+    
+    if (packagesToPublish.length > 0) {
+      console.log('\n🚀 PACKAGES TO BE PUBLISHED:');
+      packagesToPublish.forEach(release => {
+        console.log(`  - ${release.name}: ${release.oldVersion} → ${release.newVersion} (${release.type})`);
+      });
+    }
+  }
+}
+
+/**
+ * ユーザー確認を求める
+ */
+function askUserConfirmation() {
+  return new Promise((resolve) => {
+    const readline = require('readline');
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout
+    });
+    
+    console.log('\n⚠️  Please verify the packages listed above.');
+    console.log('Make sure no private packages will be accidentally published.');
+    
+    rl.question('\nDo you want to continue with the publish? (y/N): ', (answer) => {
+      rl.close();
+      resolve(answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes');
+    });
+  });
+}
+
+/**
+ * 検証チェック
+ */
+function runValidationChecks(packages) {
+  console.log('\n🔍 RUNNING VALIDATION CHECKS...\n');
+  
+  let hasErrors = false;
+  
+  // Check 1: Private packages should not have publishConfig.access
+  const privateWithPublishConfig = packages.filter(pkg => 
+    pkg.private && pkg.publishConfig.access
+  );
+  
+  if (privateWithPublishConfig.length > 0) {
+    console.error('❌ ERROR: Private packages should not have publishConfig.access:');
+    privateWithPublishConfig.forEach(pkg => {
+      console.error(`   - ${pkg.name} has publishConfig.access but is private`);
+    });
+    hasErrors = true;
+  }
+  
+  // Check 2: Public packages should have publishConfig.access
+  const publicWithoutPublishConfig = packages.filter(pkg => 
+    !pkg.private && !pkg.publishConfig.access
+  );
+  
+  if (publicWithoutPublishConfig.length > 0) {
+    console.warn('⚠️  WARNING: Public packages without explicit publishConfig.access:');
+    publicWithoutPublishConfig.forEach(pkg => {
+      console.warn(`   - ${pkg.name} (will use default access)`);
+    });
+  }
+  
+  // Check 3: Verify private packages are properly marked
+  const privatePackages = packages.filter(pkg => pkg.private);
+  if (privatePackages.length > 0) {
+    console.log('✅ Private packages detected and will be excluded from publish:');
+    privatePackages.forEach(pkg => {
+      console.log(`   - ${pkg.name} (private: true)`);
+    });
+  }
+  
+  if (!hasErrors) {
+    console.log('✅ All validation checks passed!');
+  }
+  
+  return !hasErrors;
+}
+
+/**
+ * メイン処理
+ */
+async function main() {
+  try {
+    const packages = getAllPackages();
+    const changesetStatus = getChangesetStatus();
+    
+    displayPublishablePackages(packages, changesetStatus);
+    
+    const validationPassed = runValidationChecks(packages);
+    
+    if (!validationPassed) {
+      console.error('\n❌ Validation failed. Please fix the errors before publishing.');
+      process.exit(1);
+    }
+    
+    const shouldContinue = await askUserConfirmation();
+    
+    if (!shouldContinue) {
+      console.log('\n🛑 Publish cancelled by user.');
+      process.exit(1);
+    }
+    
+    console.log('\n✅ Verification completed. Proceeding with publish...');
+    
+  } catch (error) {
+    console.error('Failed to verify publish:', error.message);
+    process.exit(1);
+  }
+}
+
+// スクリプトが直接実行された場合のみメイン処理を実行
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
## Summary
- Add verification script to prevent accidental private package publishing
- Update README with comprehensive developer documentation for publishing workflow
- Add new npm scripts for safer package management

## Changes
- **README.md**: Added developer section with publishing workflow documentation
- **package.json**: Added `verify-publish` and `publish:force` scripts
- **scripts/verify-publish.js**: New verification script to check packages before publishing
- Removed unnecessary `json` file

## Test plan
- [ ] Verify new scripts work correctly
- [ ] Test publish workflow with verification
- [ ] Confirm private packages are properly excluded

🤖 Generated with [Claude Code](https://claude.ai/code)